### PR TITLE
Add SendingAllowedChildrenNotification sample

### DIFF
--- a/Umbraco.Docs.Samples.Web/Notifications/SendingAllowedChildrenNotificationHandler.cs
+++ b/Umbraco.Docs.Samples.Web/Notifications/SendingAllowedChildrenNotificationHandler.cs
@@ -1,0 +1,48 @@
+﻿using System.Linq;
+using System.Web;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Web.Common.PublishedModels;
+
+namespace Umbraco.Docs.Samples.Web.Notifications
+{
+    internal class SendingAllowedChildrenNotificationHandler : INotificationHandler<SendingAllowedChildrenNotification>
+    {
+        public void Handle(SendingAllowedChildrenNotification notification)
+        {
+            var queryStringCollection = HttpUtility.ParseQueryString(notification.UmbracoContext.OriginalRequestUrl.Query);
+
+            const string contentIdKey = "contentId";
+
+            if (!queryStringCollection.ContainsKey(contentIdKey))
+            {
+                return;
+            }
+            var contentId = queryStringCollection[contentIdKey].TryConvertTo<int>().ResultOr(-1);
+            if (contentId == -1)
+            {
+                return;
+            }
+
+            var content = notification.UmbracoContext.Content?.GetById(true, contentId);
+            if (content == null)
+            {
+                return;
+            }
+            // allowed children as configured in the backoffice
+            var allowedChildren = notification.Children.ToList();
+            if (content.ChildrenForAllCultures != null)
+            {
+                // get all children of current page.
+                var childNodes = content.ChildrenForAllCultures.ToList();
+                // if there is a people page already created, then don't allow it anymore
+                if (childNodes.Any(x => x.ContentType.Alias == People.ModelTypeAlias))
+                {
+                    allowedChildren.RemoveAll(x => x.Alias == People.ModelTypeAlias);
+                }
+            }
+            // update the allowed children.
+            notification.Children = allowedChildren;
+        }
+    }
+}

--- a/Umbraco.Docs.Samples.Web/Notifications/UmbracoBuilderNotificationExtensions.cs
+++ b/Umbraco.Docs.Samples.Web/Notifications/UmbracoBuilderNotificationExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Cms.Core.Notifications;
+﻿using Umbraco.Cms.Core.Notifications;
 
 namespace Umbraco.Docs.Samples.Web.Notifications
 {
@@ -19,7 +18,8 @@ namespace Umbraco.Docs.Samples.Web.Notifications
                 .AddNotificationHandler<ContentUnpublishedNotification, AllUnPublishedCheck>()
                 .AddNotificationHandler<ContentUnpublishingNotification, AllUnPublishingCheck>()
                 .AddNotificationHandler<SendingContentNotification, EditorSendingContentNotificationHandler>()
-                .AddNotificationHandler<SendingMemberNotification, EditorSendingMemberNotificationHandler>();
+                .AddNotificationHandler<SendingMemberNotification, EditorSendingMemberNotificationHandler>()
+                .AddNotificationHandler<SendingAllowedChildrenNotification, SendingAllowedChildrenNotificationHandler>();
             return builder;
         }
     }


### PR DESCRIPTION
Added an example of `SendingAllowedChildrenNotification` as suggested [here](https://github.com/umbraco/UmbracoDocs/pull/4487#issuecomment-1283547228). 

In this example it's not allowed to create more than one 'People' node, but I'm wondering if there might be another scenario that makes more sense?

Besides that I'm curious if there are any code conventions? For example:

- Use of access modifiers?
- File scoped namespaces? 

Would it be a good idea to write them down somewhere?

