### PR TITLE
Change return type of CreateRootNode method

### DIFF
--- a/Umbraco.Docs.Samples.Web/Trees/FavouriteThingsTreeController.cs
+++ b/Umbraco.Docs.Samples.Web/Trees/FavouriteThingsTreeController.cs
@@ -86,7 +86,7 @@ namespace Umbraco.Docs.Samples.Web.Trees
             return menu;
         }
 
-        protected override ActionResult<TreeNode> CreateRootNode(FormCollection queryStrings)
+        protected override ActionResult<TreeNode?> CreateRootNode(FormCollection queryStrings)
         {
             var rootResult = base.CreateRootNode(queryStrings);
             if (!(rootResult.Result is null))


### PR DESCRIPTION
Change return type of the CreateRootNode since it has been changed in `UmbracoControllerBase` class:

v9:
https://github.com/umbraco/Umbraco-CMS/blob/45310d76a00e34698e49a88b89aa69ce100df624/src/Umbraco.Web.BackOffice/Trees/TreeControllerBase.cs#L216

v11:
https://github.com/umbraco/Umbraco-CMS/blob/045c755ccf5300d9b434500945f21a9077b8619f/src/Umbraco.Web.BackOffice/Trees/TreeControllerBase.cs#L245