### PR TITLE
5142 fix custom index samples

### DIFF
--- a/Umbraco.Docs.Samples.Web/CustomIndexing/ConfigureProductIndexOptions.cs
+++ b/Umbraco.Docs.Samples.Web/CustomIndexing/ConfigureProductIndexOptions.cs
@@ -35,12 +35,18 @@ namespace Umbraco.Docs.Samples.Web.CustomIndexing
 
                 options.FieldDefinitions = new(
                     new("id", FieldDefinitionTypes.Integer),
-                    new("name", FieldDefinitionTypes.FullText)
+                    new("name", FieldDefinitionTypes.FullText),
+                    //the examine dashboard uses nodeName in search results
+                    new("nodeName", FieldDefinitionTypes.InvariantCultureIgnoreCase),
+                    //__Published and path both required if using the ContentValueSetValidator
+                    new("__Published", FieldDefinitionTypes.Raw),
+                    new("path",FieldDefinitionTypes.InvariantCultureIgnoreCase)
                     );
 
                 options.UnlockIndex = true;
 
-                options.Validator = new ContentValueSetValidator(true, false, _publicAccessService, _scopeProvider, includeItemTypes: new[] { "product" });
+                //ContentValueSetValidator - requires Path, and ParentId
+                options.Validator = new ContentValueSetValidator(true,false, _publicAccessService, _scopeProvider, includeItemTypes: new[] { "product" });
                 
                 if (_settings.Value.LuceneDirectoryFactory == LuceneDirectoryFactory.SyncedTempFileSystemDirectoryFactory)
                 {

--- a/Umbraco.Docs.Samples.Web/CustomIndexing/ExamineComposer.cs
+++ b/Umbraco.Docs.Samples.Web/CustomIndexing/ExamineComposer.cs
@@ -7,12 +7,17 @@ namespace Umbraco.Docs.Samples.Web.CustomIndexing
     public class ExamineComposer : IComposer
     {
         public void Compose(IUmbracoBuilder builder)
-        {
+        {          
+
             builder.Services.AddExamineLuceneIndex<ProductIndex, ConfigurationEnabledDirectoryFactory>("ProductIndex");
+
+            builder.Services.ConfigureOptions<ConfigureProductIndexOptions>();
 
             builder.Services.AddSingleton<ProductIndexValueSetBuilder>();
 
             builder.Services.AddSingleton<IIndexPopulator, ProductIndexPopulator>();
+
+ 
         }
     }
 }

--- a/Umbraco.Docs.Samples.Web/CustomIndexing/ProductIndexValueSetBuilder.cs
+++ b/Umbraco.Docs.Samples.Web/CustomIndexing/ProductIndexValueSetBuilder.cs
@@ -1,4 +1,4 @@
-using Examine;
+﻿using Examine;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Infrastructure.Examine;
 
@@ -14,6 +14,12 @@ namespace Umbraco.Docs.Samples.Web.CustomIndexing
                 {
                     ["name"] = content.Name,
                     ["id"] = content.Id,
+                    // nodeName used in the Examine Dashboard backoffice search results
+                    ["nodeName"] = content.Name,
+                    //__Published and path are required if using core ContentValueSetValidator to apply a Validation option to filter results
+                    ["__Published"] = content.Published ? "y" : "n",
+                    ["path"] = content.Path
+
                 };
 
                 yield return new ValueSet(content.Id.ToString(), "content",content.ContentType.Alias,indexValues);

--- a/Umbraco.Docs.Samples.Web/CustomIndexing/ProductIndexValueSetBuilder.cs
+++ b/Umbraco.Docs.Samples.Web/CustomIndexing/ProductIndexValueSetBuilder.cs
@@ -1,4 +1,4 @@
-﻿using Examine;
+using Examine;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Infrastructure.Examine;
 
@@ -16,7 +16,7 @@ namespace Umbraco.Docs.Samples.Web.CustomIndexing
                     ["id"] = content.Id,
                 };
 
-                yield return new ValueSet(content.Id.ToString(), "content", indexValues);
+                yield return new ValueSet(content.Id.ToString(), "content",content.ContentType.Alias,indexValues);
             }
         }
     }


### PR DESCRIPTION
1. Need to add ContentType as IndexType, otherwise __NodeTypeAlias is always none and the filter by 'product' doesn't work
2. The ConfigureProdutIndexOptions needs registering with configureoptions
3. Both path and __Published need to be in the index, if using the ContentSetValueValidator to filter by Product, as these also check if content in recycle bin or published, without them nothing is indexed.